### PR TITLE
Update dependencies to support Illuminate packages v11 and v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/session": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/view": "^6.0|^7.0|^8.0|^9.0|^10.0"
+        "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/session": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/view": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~8.5|^9.5.10"
     },


### PR DESCRIPTION
Extended compatibility for Illuminate packages in `require` and `require-dev` sections to include versions 11.x and 12.x. This ensures the project stays up-to-date with the latest framework releases and maintains broader version support.