### PR TITLE
Set minimum-stability to stable in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.x-dev"
+            "dev-master": "6.x"
         },
         "laravel": {
             "providers": [
@@ -52,7 +52,7 @@
             }
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "abandoned": "spatie/laravel-html",
     "prefer-stable": true
 }


### PR DESCRIPTION
Changed the `minimum-stability` setting from `dev` to `stable` to ensure a more reliable dependency resolution process. This helps avoid installing unstable versions of packages by default.